### PR TITLE
Fix : Resolve UI State Issue for User Search Feature

### DIFF
--- a/lib/presentation/view/screen/search/search_screen.dart
+++ b/lib/presentation/view/screen/search/search_screen.dart
@@ -111,6 +111,7 @@ class _SearchScreenState extends State<SearchScreen> {
                       _userListByKeywordViewModel.setKeyword(value: newKeyword);
                       /// Delay for 300 milliseconds and then fetch users by new keyword
                       Future.delayed(const Duration(milliseconds: 300), () {
+                        _userListByKeywordViewModel.reinitialize();
                         _userListByKeywordViewModel.getUserListByKeyword();
                       });
                     },
@@ -152,6 +153,7 @@ class _SearchScreenState extends State<SearchScreen> {
   }
 
   // TODO : Enhance the loading UI
+  /// Loading UI
   Widget buildLoadingStateUI() {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
@@ -182,6 +184,7 @@ class _SearchScreenState extends State<SearchScreen> {
   //   );
   // }
 
+  /// Fail UI
   Widget buildFailStateUI() {
     return Center(
       child: CustomErrorWidget(listener: () {
@@ -190,6 +193,7 @@ class _SearchScreenState extends State<SearchScreen> {
     );
   }
 
+  /// Success UI
   Widget buildSuccessStateUI() {
     return ValueListenableBuilder<List<SimpleUserInfoModel>>(
         valueListenable: _userListByKeywordViewModel.currentListNotifier,

--- a/lib/presentation/viewmodel/user/list/user_list_by_keyword_viewmodel.dart
+++ b/lib/presentation/viewmodel/user/list/user_list_by_keyword_viewmodel.dart
@@ -31,7 +31,6 @@ class UserListByKeywordViewModel {
 
   setKeyword({required String value}) {
     _keyword = value;
-    _reinitialize();
   }
 
   /// Fetch user list by keyword
@@ -97,7 +96,7 @@ class UserListByKeywordViewModel {
   }
 
   /// Reinitialize
-  void _reinitialize() {
+  void reinitialize() {
     _setCurrentList(list: []);
     _setPage(value: 1);
     setHasNext(value: true);


### PR DESCRIPTION
[Completed]
- Resolve the initialization order problem with [userListState]

[Review]
The issue was that [userListState] was being set to [Loading] as soon as the search keyword was being edited However, in reality, the [UserListByKeywordViewModel] starts the search API process 300 milliseconds after keyword editing As a result, the [SearchScreen] briefly displayed an empty list UI for 300 milliseconds before actually initiating the user search